### PR TITLE
Fix for Chef::Exceptions::ImmutableAttributeModification

### DIFF
--- a/recipes/manage_hostsfile.rb
+++ b/recipes/manage_hostsfile.rb
@@ -9,7 +9,7 @@ managed_hosts.merge!(managed_hosts_bag['maps']) if managed_hosts_bag
 managed_hosts.merge!(node[:dnsmasq][:managed_hosts].to_hash) if node[:dnsmasq][:managed_hosts]
 
 managed_hosts.each do |ip, host|
-  host = host.is_a?(Array) ? host : host.split(' ')
+  host = host.is_a?(Array) ? host.each.collect {|x|x} : host.split(' ')
   hosts_file_entry ip do
     hostname host.shift
     aliases host unless host.empty?


### PR DESCRIPTION
workaround for Chef::Exceptions::ImmutableAttributeModification when managed_hosts in node attributes are witten as array.

http://www.opscode.com/blog/2013/02/05/chef-11-in-depth-attributes-changes/
