### PR TITLE
Notifies :immediately is specified, DNS can cut over mid-chef run

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chrisroberts.code@gmail.com'
 license 'Apache 2.0'
 description 'Installs and configures dnsmasq'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.1'
+version '0.2.2'
 
 depends 'hosts_file'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chrisroberts.code@gmail.com'
 license 'Apache 2.0'
 description 'Installs and configures dnsmasq'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.0'
+version '0.2.1'
 
 depends 'hosts_file'
 

--- a/recipes/dns.rb
+++ b/recipes/dns.rb
@@ -9,6 +9,8 @@ end
 template '/etc/dnsmasq.d/dns.conf' do
   source 'dynamic_config.erb'
   mode 0644
+  retries 3
+  retry_delay 3
   variables(
     :config => dns_config,
     :list => node['dnsmasq']['dns_options']


### PR DESCRIPTION
If this happens, the retry attribute will prevent chef from failing.

This was happening intermittently during AWS provisioning (about 30-50% of all boxes)

Example of the (now prevented) stacktrace

```
[2014-08-27T22:13:52+00:00] INFO: Processing template[/etc/dnsmasq.d/dns.conf] action create (dnsmasq::dns line 9)

================================================================================
Error executing action `create` on resource 'template[/etc/dnsmasq.d/dns.conf]'
================================================================================

SocketError
-----------
Error connecting to https://s3-external-1.amazonaws.com/opscode-platform-production-data/organization-XXXXXX/checksum-YYYYY?AWSAccessKeyId=zZZZZZZ&Expires=11111111&Signature=00000000000%3D - getaddrinfo: Name or service not known

Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/dnsmasq/recipes/dns.rb

  9: template '/etc/dnsmasq.d/dns.conf' do
 10:   source 'dynamic_config.erb'
 11:   mode 0644
 12:   variables(
 13:     :config => dns_config,
 14:     :list => node['dnsmasq']['dns_options']
 15:   )
 16:   notifies :restart, resources(:service => 'dnsmasq'), :immediately
 17: end

Compiled Resource:
------------------
# Declared in /var/chef/cache/cookbooks/dnsmasq/recipes/dns.rb:9:in `from_file'

template("/etc/dnsmasq.d/dns.conf") do
  provider Chef::Provider::Template
  action "create"
  retries 0
  retry_delay 2
  guard_interpreter :default
  path "/etc/dnsmasq.d/dns.conf"
  backup 5
  atomic_update true
  source "dynamic_config.erb"
  variables {:config=>{"no-poll"=>nil, "no-resolv"=>nil, "server"=>["/my2.example.com.com/10.222.222.224", "/my.example.com/10.222.222.223", "/ec2.internal/10.222.222.222", "8.8.8.8", "8.8.4.4"], "no-dhcp-interface="=>nil}, :list=>[]}
  cookbook_name "dnsmasq"
  recipe_name "dns"
  mode 420
end
```
