### PR TITLE
dnsmasq: run `cookstyle -a .`

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Sous-Chefs'
 maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures dnsmasq'
-long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+
 chef_version      '>= 14.0'
 source_url        'https://github.com/sous-chefs/dnsmasq'
 issues_url        'https://github.com/sous-chefs/dnsmasq/issues'


### PR DESCRIPTION
# Description

`cookstyle -a .` improvements to cookbook

Ran from latest chef/chefdk docker image.
```
root@1b30b6bf5af8:/home# chef --version
ChefDK version: 4.4.27
Chef Infra Client version: 15.3.14
Chef InSpec version: 4.16.0
Test Kitchen version: 2.3.3
Foodcritic version: 16.1.1
Cookstyle version: 5.6.2
```

## Issues Resolved

https://github.com/sous-chefs/dnsmasq/issues/45

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
