### PR TITLE
Stublistener for ubuntu

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,4 +11,8 @@ default['dnsmasq']['dns_options'] = []
 default['dnsmasq']['managed_hosts'] = {}
 default['dnsmasq']['managed_hosts_bag'] = 'managed_hosts'
 default['dnsmasq']['user'] = 'dnsmasq'
-default['dnsmasq']['stublistener'] = if platform?('ubuntu') && node['platform_version'].to_i <= 20 ? 'yes' : 'no'
+default['dnsmasq']['stublistener'] = if platform?('ubuntu') && node['platform_version'].to_i <= 20
+                                       'yes'
+                                     else
+                                       'no'
+                                     end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,8 +11,4 @@ default['dnsmasq']['dns_options'] = []
 default['dnsmasq']['managed_hosts'] = {}
 default['dnsmasq']['managed_hosts_bag'] = 'managed_hosts'
 default['dnsmasq']['user'] = 'dnsmasq'
-default['dnsmasq']['stublistener'] = if platform?('ubuntu') && node['platform_version'].to_i <= 20
-  'yes'
-else
-  'no'
-end
+default['dnsmasq']['stublistener'] = if platform?('ubuntu') && node['platform_version'].to_i <= 20 ? 'yes' : 'no'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@ default['dnsmasq']['managed_hosts'] = {}
 default['dnsmasq']['managed_hosts_bag'] = 'managed_hosts'
 default['dnsmasq']['user'] = 'dnsmasq'
 default['dnsmasq']['stublistener'] = if platform?('ubuntu') && node['platform_version'].to_i <= 20
-                                       'yes'
+                                       node['dnsmasq']['enable_dhcp'] ? 'no' : 'yes'
                                      else
                                        'no'
                                      end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,8 @@ default['dnsmasq']['dns_options'] = []
 default['dnsmasq']['managed_hosts'] = {}
 default['dnsmasq']['managed_hosts_bag'] = 'managed_hosts'
 default['dnsmasq']['user'] = 'dnsmasq'
+default['dnsmasq']['stublistener'] = if platform?('ubuntu') && node['platform_version'].to_i == 20
+  'yes'
+else
+  'no'
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ default['dnsmasq']['dns_options'] = []
 default['dnsmasq']['managed_hosts'] = {}
 default['dnsmasq']['managed_hosts_bag'] = 'managed_hosts'
 default['dnsmasq']['user'] = 'dnsmasq'
-default['dnsmasq']['stublistener'] = if platform?('ubuntu') && node['platform_version'].to_i == 20
+default['dnsmasq']['stublistener'] = if platform?('ubuntu') && node['platform_version'].to_i <= 20
   'yes'
 else
   'no'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,13 +13,13 @@ verifier:
   name: inspec
 
 platforms:
-  - amazonlinux-2
-  - debian-9
-  - debian-10
-  - centos-7
-  - centos-8
-  - ubuntu-1804
-  - ubuntu-2004
+  - name: amazonlinux-2
+  - name: debian-9
+  - name: debian-10
+  - name: centos-7
+  - name: centos-8
+  - name: ubuntu-18.04
+  - name: ubuntu-20.04
 
 suites:
   - name: default
@@ -39,3 +39,5 @@ suites:
           tftp-root: '/var/lib/tftpboot'
           enable-tftp: null
           interface: 'eth1'
+
+  - name: nodhcp

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description       'Installs and configures dnsmasq'
 chef_version      '>= 15.3'
 source_url        'https://github.com/sous-chefs/dnsmasq'
 issues_url        'https://github.com/sous-chefs/dnsmasq/issues'
-version           '1.1.15'
+version           '1.1.13'
 
 supports 'ubuntu'
 supports 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description       'Installs and configures dnsmasq'
 chef_version      '>= 15.3'
 source_url        'https://github.com/sous-chefs/dnsmasq'
 issues_url        'https://github.com/sous-chefs/dnsmasq/issues'
-version           '1.1.13'
+version           '1.1.14'
 
 supports 'ubuntu'
 supports 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description       'Installs and configures dnsmasq'
 chef_version      '>= 15.3'
 source_url        'https://github.com/sous-chefs/dnsmasq'
 issues_url        'https://github.com/sous-chefs/dnsmasq/issues'
-version           '1.1.14'
+version           '1.1.15'
 
 supports 'ubuntu'
 supports 'debian'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,7 @@ if platform?('ubuntu') && node['platform_version'] >= '18.04'
 
   file 'Fix systemd-resolved conflict' do
     path '/etc/systemd/resolved.conf.d/dnsmasq.conf'
-    content "[Resolve]\nDNSStubListener=no"
+    content "[Resolve]\nDNSStubListener=#{node['dnsmasq']['stublistener']}"
     notifies :restart, 'service[systemd-resolved]', :immediately
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,5 @@
 if platform?('ubuntu') && node['platform_version'] >= '18.04'
+  Chef::Log.debug("Ubuntu 18.04 or higher detected, configuring systemd-resolved with DNSStubListener option at #{node['dnsmasq']['stublistener']}")
   directory '/etc/systemd/resolved.conf.d'
 
   file 'Fix systemd-resolved conflict' do


### PR DESCRIPTION
# Description
Adding choice for Systemd Resolved DNSStubListener option for Ubuntu

## Issues Resolved
Resolve issue on DNS resolution not working on Ubunut 20.04 https://github.com/sous-chefs/dnsmasq/issues/79

## Check List
- [ ] Adding debug log for attribute ['dnsmasq']['stublistener']
- [ ] Create an attribute to select the value ['dnsmasq']['stublistener'] depending of the Ubuntu platform version
 
