### PR TITLE
feat!: document custom resource migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@
 
 Install and configure dnsmasq.
 
+## Breaking Change
+
+Upgrading from older versions of this cookbook is a breaking change. The
+custom-resource release removes the legacy `recipes/` and `attributes/`
+interface, so existing `include_recipe 'dnsmasq::...'` calls and
+`node['dnsmasq']` attribute overrides are no longer the supported upgrade path.
+
+Before you roll this version out, rewrite those recipe and attribute-based
+configurations to use the `dnsmasq`, `dnsmasq_dns`, `dnsmasq_dhcp`, or
+`dnsmasq_managed_hosts` resources documented in [migration.md](migration.md).
+
 ## Maintainers
 
 This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of Chef cookbook maintainers working together to maintain important cookbooks. If you’d like to know more please visit [sous-chefs.org](https://sous-chefs.org/) or come chat with us on the Chef Community Slack in [#sous-chefs](https://chefcommunity.slack.com/messages/C2V7B88SF).

--- a/migration.md
+++ b/migration.md
@@ -1,0 +1,74 @@
+# Migration Guide
+
+## Breaking Change
+
+This cookbook now uses custom resources as its public interface. Operators
+upgrading from older cookbook versions must treat this as a breaking change:
+the legacy `recipes/` and `attributes/` interface is no longer the supported
+way to configure dnsmasq.
+
+If your existing wrapper cookbooks or roles do either of the following, update
+them before you promote the new cookbook version:
+
+* `include_recipe 'dnsmasq::default'`, `dnsmasq::dns`, `dnsmasq::dhcp`, or
+  `dnsmasq::manage_hostsfile`
+* set configuration with `node['dnsmasq'][...]` attributes
+
+Those patterns need to move to resource declarations instead.
+
+## What changed
+
+The cookbook configuration surface moved from recipes and node attributes to
+custom resources:
+
+* `dnsmasq`
+* `dnsmasq_dns`
+* `dnsmasq_dhcp`
+* `dnsmasq_managed_hosts`
+
+DNS, DHCP, and managed-host settings now belong on resource properties instead
+of node attributes.
+
+## How to migrate
+
+Legacy pattern:
+
+```ruby
+include_recipe 'dnsmasq::default'
+include_recipe 'dnsmasq::dns'
+include_recipe 'dnsmasq::dhcp'
+
+node.default['dnsmasq']['dns']['server'] = '8.8.8.8'
+node.default['dnsmasq']['dhcp']['dhcp-range'] = '10.0.0.5,10.0.0.15,12h'
+```
+
+Resource-first pattern:
+
+```ruby
+dnsmasq 'default' do
+  enable_dns true
+  enable_dhcp true
+  managed_hosts_data_bag false
+  dns_config(
+    'server' => '8.8.8.8'
+  )
+  dhcp_config(
+    'dhcp-range' => '10.0.0.5,10.0.0.15,12h',
+    'except-interface' => 'lo'
+  )
+  managed_hosts(
+    '10.0.0.20' => ['router.test.lab', 'router']
+  )
+end
+```
+
+## Attribute migration
+
+Move legacy configuration hashes into resource properties:
+
+* DNS settings -> `dns_config` and `dns_options`
+* DHCP settings -> `dhcp_config` and `dhcp_options`
+* managed hosts -> `managed_hosts`, `managed_hosts_data_bag`, `managed_hosts_data_bag_item`
+
+If you prefer more granular declarations, use `dnsmasq_dns`, `dnsmasq_dhcp`,
+and `dnsmasq_managed_hosts` directly.


### PR DESCRIPTION
Adds an explicit breaking-change note for operators upgrading from legacy recipe- and attribute-based cookbook releases. Includes a migration guide and pairs with a feat! commit plus BREAKING CHANGE footer so Release Please will cut a major release.