### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,3 +12,6 @@ name: conventional-commits
 jobs:
   conventional-commits:
     uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4
+    permissions:
+      pull-requests: read
+    secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,13 +36,11 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/
 .coverage/
 .zero-knife.rb
-Policyfile.lock.json
 
 # vagrant stuff
 .vagrant/

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'cookstyle'
 gem 'chefspec', '>= 9.3.7'
-gem 'berkshelf'
 gem 'fauxhai-chef'
 gem 'rspec-its'

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,0 +1,110 @@
+{
+  "revision_id": "b098ee35a288790ac4437a3e3fe45e1dc9cfff8aeb316bd5ac18ab3bbce782fe",
+  "name": "dnsmasq",
+  "run_list": [
+    "recipe[test::default]"
+  ],
+  "named_run_lists": {
+    "default": [
+      "recipe[test::default]"
+    ]
+  },
+  "included_policy_locks": [
+
+  ],
+  "cookbook_locks": {
+    "dnsmasq": {
+      "version": "2.0.0",
+      "identifier": "7beb596f93afa4a7987b04ad366b048e2eebd749",
+      "dotted_decimal_identifier": "34880191491977124.47173975237539435.5008719075145",
+      "source": ".",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": null,
+        "revision": "caeba6aa6c2ec68024f7fa563c40310d8330cfe2",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main"
+        ]
+      },
+      "source_options": {
+        "path": "."
+      }
+    },
+    "hostsfile": {
+      "version": "3.0.1",
+      "identifier": "bfd04b43ad8f700502796f33f112e5abc95154e5",
+      "dotted_decimal_identifier": "53990742228307824.1410095463526674.252525979718885",
+      "cache_key": "hostsfile-71ed85e0da701378e2f3f791881ca5e832b73f08",
+      "origin": "https://github.com/customink-webops/hostsfile.git",
+      "source_options": {
+        "git": "https://github.com/customink-webops/hostsfile.git",
+        "revision": "71ed85e0da701378e2f3f791881ca5e832b73f08",
+        "branch": "master"
+      }
+    },
+    "test": {
+      "version": "0.0.1",
+      "identifier": "9fc585ece3840906bccb6e1554a7bdb4dc29d068",
+      "dotted_decimal_identifier": "44971700292649993.1896431771538599.208584485490792",
+      "source": "test/cookbooks/test",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": null,
+        "revision": "caeba6aa6c2ec68024f7fa563c40310d8330cfe2",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main"
+        ]
+      },
+      "source_options": {
+        "path": "test/cookbooks/test"
+      }
+    }
+  },
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+
+  },
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "dnsmasq",
+        ">= 0.0.0"
+      ],
+      [
+        "hostsfile",
+        ">= 0.0.0"
+      ],
+      [
+        "test",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "dnsmasq (2.0.0)": [
+        [
+          "hostsfile",
+          ">= 0.0.0"
+        ]
+      ],
+      "hostsfile (3.0.1)": [
+
+      ],
+      "test (0.0.1)": [
+        [
+          "dnsmasq",
+          ">= 0.0.0"
+        ]
+      ]
+    }
+  }
+}

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'dnsmasq'
+
+run_list 'test::default'
+
+cookbook 'dnsmasq', path: '.'
+cookbook 'hostsfile', git: 'https://github.com/customink-webops/hostsfile.git', branch: 'master'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- add Policyfile.rb and commit Policyfile.lock.json for dependency resolution
- source hostsfile explicitly from GitHub instead of Berkshelf/Supermarket resolution
- remove Berksfile/Berkshelf wiring and update ChefSpec/Copilot setup for Policyfile

## Validation
- chef install Policyfile.rb
- chef update Policyfile.rb
- cookstyle
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation
- markdownlint-cli2 "**/*.md"
- yamllint .
- actionlint
- git diff --check
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen diagnose default-ubuntu-2404
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2404 --destroy=always